### PR TITLE
Reformat publication linkouts

### DIFF
--- a/publications.html
+++ b/publications.html
@@ -23,23 +23,23 @@ title: Publications
           <div class="d-flex">
             <a
               class="publinks"
-              href="https://pubmed.ncbi.nlm.nih.gov/34426512/"
-              title="project website"
+              href="https://pubmed.ncbi.nlm.nih.gov/36302553/"
+              title="linkout to PubMed"
             >
-              View <i class="fas fa-external-link-alt"></i
-            ></a>
+              PMID <i class="fas fa-external-link-alt"></i>
+            </a>
             &nbsp; &nbsp;
             <a
               class="publinks"
-              href="https://pubmed.ncbi.nlm.nih.gov/36302553/"
-              title="pubmed link"
+              href="http://genesdev.cshlp.org/content/36/17-18/985.long"
+              title="linkout to full text"
             >
               PDF <i class="fas fa-file-pdf"></i
             ></a>
           </div>
         </div>
-      </div> -->
-      
+      </div>
+
       <div class="row publication">
         <div class="col-md-1 number">
           <h6>02</h6>
@@ -56,15 +56,15 @@ title: Publications
             <a
               class="publinks"
               href="https://pubmed.ncbi.nlm.nih.gov/35483960/"
-              title="project website"
+              title="linkout to PubMed"
             >
-              View <i class="fas fa-external-link-alt"></i
+              PMID <i class="fas fa-external-link-alt"></i
             ></a>
             &nbsp; &nbsp;
             <a
               class="publinks"
               href="https://genome.cshlp.org/content/32/5/878.long"
-              title="pubmed link"
+              title="linkout to full text"
             >
               PDF <i class="fas fa-file-pdf"></i
             ></a>
@@ -89,15 +89,15 @@ title: Publications
             <a
               class="publinks"
               href="https://pubmed.ncbi.nlm.nih.gov/35440038/"
-              title="project website"
+              title="linkout to PubMed"
             >
-              View <i class="fas fa-external-link-alt"></i
+              PMID <i class="fas fa-external-link-alt"></i
             ></a>
             &nbsp; &nbsp;
             <a
               class="publinks"
               href="https://genomebiology.biomedcentral.com/articles/10.1186/s13059-022-02671-5"
-              title="pubmed link"
+              title="linkout to full text"
             >
               PDF <i class="fas fa-file-pdf"></i
             ></a>
@@ -124,15 +124,15 @@ title: Publications
             <a
               class="publinks"
               href="https://pubmed.ncbi.nlm.nih.gov/35139076/"
-              title="project website"
+              title="linkout to PubMed"
             >
-              View <i class="fas fa-external-link-alt"></i
-            ></a>
+              PMID <i class="fas fa-external-link-alt"></i>
+            </a>
             &nbsp; &nbsp;
             <a
               class="publinks"
               href="https://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1009859"
-              title="pubmed link"
+              title="linkout to full text"
             >
               PDF <i class="fas fa-file-pdf"></i
             ></a>
@@ -141,7 +141,6 @@ title: Publications
       </div>
 
       <!-- <div class="publication"></div> -->
-
       <div class="row publication">
         <div class="col-md-1 number">
           <h6>05</h6>
@@ -160,15 +159,15 @@ title: Publications
             <a
               class="publinks"
               href="https://pubmed.ncbi.nlm.nih.gov/34652274/"
-              title="project website"
+              title="linkout to PubMed"
             >
-              View <i class="fas fa-external-link-alt"></i
+              PMID <i class="fas fa-external-link-alt"></i
             ></a>
             &nbsp; &nbsp;
             <a
               class="publinks"
               href="https://elifesciences.org/articles/71013"
-              title="pubmed link"
+              title="linkout to full text"
             >
               PDF <i class="fas fa-file-pdf"></i
             ></a>


### PR DESCRIPTION
Updated linkouts to be more descriptive
- changed the PubMed linkouts to read "PMID" instead of "View"
- changed the string displayed by hovering the "PMID" links to "linkout to PubMed"
- changed the string displayed by hovering the "PDF" links to "linkout to full text" Fixed mix-up of hrefs for Mittal 2022 linkouts update Removed leftover comment tail ("-->")